### PR TITLE
Bump version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
     name = "bell-vrc-libraries"
-    version = "0.1.0"
+    version = "0.1.1"
     description = ""
     license = "MIT"
     readme = "README.md"


### PR DESCRIPTION
Try to hopefully fix the pypi 403 errors by re-publishing:

https://files.pythonhosted.org/packages/27/15/495e3ee1832235673926ebfb09025a08a54d821ed52d088983acc61f82c9/bell_vrc_libraries-0.1.0-py3-none-any.whl
```xml
<Error>
<Code>SignatureDoesNotMatch</Code>
<Message>The request signature we calculated does not match the signature you provided. Check your Google secret key and signing method.</Message>
<StringToSign>GET Thu, 02 Jun 2022 21:59:24 GMT /pypi-files/packages/27/15/495e3ee1832235673926ebfb09025a08a54d821ed52d088983acc61f82c9/bell_vrc_libraries-0.1.0-py3-none-any.whl</StringToSign>
</Error>
```